### PR TITLE
Add VM smoke diagnostics and kernel path compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,6 @@ jobs:
             io.artifacthub.package.keywords=${{ env.IMAGE_KEYWORDS }}
             io.artifacthub.package.license=NOASSERTION
             io.artifacthub.package.prerelease=true
-            containers.bootc=1
           sep-tags: " "
           sep-annotations: " "
 
@@ -109,8 +108,18 @@ jobs:
           sudo apt-get install -y qemu-system-x86 qemu-utils sshpass
 
       - name: VM smoke test (headless qemu + ssh)
+        env:
+          CI_ARTIFACT_DIR: ${{ runner.temp }}/vm-smoke-artifacts
         run: |
           ./scripts/ci/vm-smoke.sh "${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
+
+      - name: Upload VM smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vm-smoke-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/vm-smoke-artifacts
+          if-no-files-found: warn
 
       - name: Tag for registry
         run: |

--- a/README.md
+++ b/README.md
@@ -106,5 +106,5 @@ See `docs/bootcrew-comparison.md` for how bootcrew’s Arch bootc images differ 
 - Immediate objective is to keep the image building while preserving the first VM login/session path.
 - Desktop defaults are now intentionally Omarchy-inspired but trimmed to the current package set and no-AUR policy.
 - See `docs/technical-status.md` for what is working, what is assumed, and what is deferred.
-- Current CI focus: keep image build + headless VM smoke validation green.
-- Next milestone remains: harden the smoke path with richer failure artifacts/log collection.
+- Current CI focus: keep image build + headless VM smoke validation green, with retained diagnostics from host, QEMU, and guest state.
+- Next milestone: broaden stability coverage beyond the single headless smoke path.

--- a/build/10-base.sh
+++ b/build/10-base.sh
@@ -21,6 +21,36 @@ fi
 
 echo "::endgroup::"
 
+echo "::group:: Add kernel-version compatibility symlinks"
+
+latest_kver=""
+if [[ -d /usr/lib/modules ]]; then
+    latest_kver="$(
+        find /usr/lib/modules -mindepth 1 -maxdepth 1 -type d -printf '%f\n' \
+            | sort -V \
+            | tail -n 1
+    )"
+fi
+
+if [[ -n "${latest_kver}" ]]; then
+    if [[ -f /boot/initramfs-linux.img ]]; then
+        ln -sfn initramfs-linux.img "/boot/initramfs-${latest_kver}.img"
+        ln -sfn ../../../boot/initramfs-linux.img "/usr/lib/modules/${latest_kver}/initramfs.img"
+    fi
+
+    if [[ -f /boot/vmlinuz-linux ]]; then
+        ln -sfn vmlinuz-linux "/boot/vmlinuz-${latest_kver}"
+    fi
+
+    ls -l /boot/initramfs-linux.img "/boot/initramfs-${latest_kver}.img" || true
+    ls -l /boot/vmlinuz-linux "/boot/vmlinuz-${latest_kver}" || true
+    ls -l "/usr/lib/modules/${latest_kver}/initramfs.img" || true
+else
+    echo "WARN: no kernel version directory found under /usr/lib/modules"
+fi
+
+echo "::endgroup::"
+
 echo "::group:: Create default POC user"
 
 # Explicit VM login user for POC smoke tests.

--- a/docs/discovery-2026-03-28-agent-handoff.md
+++ b/docs/discovery-2026-03-28-agent-handoff.md
@@ -1,0 +1,256 @@
+# Agent Handoff: 2026-03-28
+
+## Goal the user set
+
+Finish `omarchy-bootc` enough that:
+
+- it produces a working bootable VM artifact at minimum, and
+- it moves toward the user's long-term goal of switching from a Bluefin/Fedora host to an Arch/Omarchy-style image.
+
+The user explicitly wants this to track Jorge Castro / Bluefin / bootc ideas where possible, but not become a Fedora/Dakota clone.
+
+## High-level repo state
+
+- Repo: `joshyorko/omarchy-bootc`
+- Local branch: `main`
+- Local status when I stopped:
+  - modified: `build/10-base.sh`
+  - modified: `scripts/ci/vm-smoke.sh`
+- Last known `main` head from local git/GitHub checks: `44c3535`
+
+## What I learned from GitHub / CI
+
+I used `gh` before the permission mode flipped back to restricted.
+
+### Open / recent PR state
+
+- Open PR:
+  - `#12` draft, title: `Integrate real bootc-on-Arch flow and native install-to-disk outputs`
+  - status was `MERGEABLE` but `UNSTABLE`
+  - last updated: `2026-03-23`
+- Recently merged PRs were all from `2026-03-22` to `2026-03-23`
+- There has effectively been no fresh PR activity since then
+
+### Current failure on `main`
+
+The recurring scheduled `Build and optionally publish bootc image` workflow on `main` was failing daily.
+
+Latest failure I inspected:
+
+- Run: `23683086344`
+- URL: `https://github.com/joshyorko/omarchy-bootc/actions/runs/23683086344`
+
+Important detail:
+
+- The image build itself now succeeds.
+- The failure is in the VM artifact path, specifically `VM smoke test (headless qemu + ssh)`.
+- The actual failure occurs earlier inside `bootc-image-builder` while generating the qcow2 manifest.
+
+Critical log snippet from the failed run:
+
+`bootc-image-builder` ends with:
+
+- `failed to run lsinitrd --mod --kver 6.19.9-arch1-1`
+- `No <initramfs file> specified and the default image '' cannot be accessed!`
+
+Meaning:
+
+- the Arch image has an initramfs,
+- but not at a kernel-version-addressable path that `lsinitrd -k <kver>` can resolve.
+
+## What I verified locally
+
+I built the local image successfully with:
+
+- `just build`
+
+The build completes locally and produces `localhost/omarchy-bootc:stable`.
+
+I then inspected the built image with `podman run`.
+
+### Important filesystem facts from the built image
+
+Observed in the image:
+
+- `/boot/initramfs-linux.img`
+- `/boot/vmlinuz-linux`
+- `/usr/lib/modules/6.19.9-arch1-1/`
+
+But this command failed inside the image:
+
+- `lsinitrd -k 6.19.9-arch1-1`
+
+That reproduces the CI symptom directly.
+
+### Key discovery
+
+I tested two possible compatibility fixes inside throwaway containers:
+
+1. symlink `/usr/lib/modules/6.19.9-arch1-1/initramfs.img -> /boot/initramfs-linux.img`
+2. symlink `/boot/initramfs-6.19.9-arch1-1.img -> /boot/initramfs-linux.img`
+
+Result:
+
+- either of those makes `lsinitrd -k 6.19.9-arch1-1` succeed
+
+So the current blocker is not "no initramfs". It is "Arch naming does not match what `bootc-image-builder` expects when it resolves by kernel version."
+
+## Local code changes I made
+
+### 1. `build/10-base.sh`
+
+I added a compatibility block after base package install and before user creation.
+
+Purpose:
+
+- discover the latest kernel version under `/usr/lib/modules`
+- create:
+  - `/boot/initramfs-${kver}.img -> initramfs-linux.img`
+  - `/boot/vmlinuz-${kver} -> vmlinuz-linux`
+  - `/usr/lib/modules/${kver}/initramfs.img -> ../../../boot/initramfs-linux.img`
+
+Reason:
+
+- this gives `bootc-image-builder` / `lsinitrd -k` the versioned initramfs lookup it expects
+- without changing Arch's native preset naming
+
+### 2. `scripts/ci/vm-smoke.sh`
+
+I fixed an existing shellcheck warning:
+
+- changed `hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22`
+- to `hostfwd=tcp:127.0.0.1:"${SSH_PORT}"-:22`
+
+Reason:
+
+- shellcheck in this repo treats warnings as failures in practice
+- this was existing lint debt that would block a PR even if the image fix worked
+
+### 3. Shellcheck status
+
+After the above edit, this passed locally:
+
+- `shellcheck build/10-base.sh build/20-omarchy.sh build/30-services.sh scripts/ci/vm-smoke.sh`
+
+## Build status when interrupted
+
+After patching, I started another `just build`.
+
+What was confirmed before interruption:
+
+- the build re-entered `build/10-base.sh`
+- the new symlink logic executed correctly
+- logs showed the symlinks being created exactly as intended
+
+I did **not** finish the full post-patch end-to-end verification because the turn was interrupted.
+
+Specifically, I did **not** get to complete:
+
+- final `just build` completion check after the patch
+- `just build-qcow2`
+- `just run-vm`
+
+## What the next agent should do first
+
+1. Re-run:
+   - `just build`
+2. If successful, verify inside the built image:
+   - `ls -l /boot/initramfs-*`
+   - `ls -l /usr/lib/modules/*/initramfs.img`
+   - `lsinitrd -k <kver>`
+3. Then run:
+   - `just build-qcow2`
+4. If qcow2 succeeds, run:
+   - `just run-vm`
+   - or at minimum inspect the produced artifact under `output/`
+
+The highest-value checkpoint is whether `bootc-image-builder` now gets past manifest generation.
+
+## If the qcow2 path still fails
+
+Likely next places to inspect:
+
+- `scripts/ci/vm-smoke.sh`
+- `image/disk.toml`
+- whether `bootc-image-builder` also expects a versioned kernel path beyond the initramfs path
+- whether Arch needs stronger alignment with bootcrew's initramfs/rootfs prep
+
+Possible follow-up fixes if the simple symlink approach is insufficient:
+
+- add a dracut config that emits a versioned initramfs path directly
+- rebuild initramfs explicitly the way bootcrew does
+- move from the current "bootc-image-builder from outside the image" model toward real bootc-in-image generation
+
+## What I learned from bootcrew references
+
+I fetched these upstream reference files:
+
+- `https://raw.githubusercontent.com/bootcrew/mono/main/shared/initramfs.sh`
+- `https://raw.githubusercontent.com/bootcrew/mono/main/arch/Containerfile`
+- `https://raw.githubusercontent.com/bootcrew/arch-bootc/main/Containerfile`
+
+Important takeaways:
+
+- bootcrew's real Arch bootc images:
+  - build/install `bootc` inside the image
+  - add dracut drop-ins for `bootc` / `ostree`
+  - run `dracut --force .../initramfs.img`
+  - prepare the rootfs for image-based semantics, not just pacman DB relocation
+- this repo currently does **not** do that full prep
+- this repo is still using a weaker compatibility approach:
+  - Arch image + `bootc-image-builder` container outside the image
+  - minimal pacman DB relocation
+  - no true `bootc install` path inside the Arch image
+
+## What this means for the user's "switch from Bluefin to Arch image" idea
+
+Short version:
+
+- Getting qcow2 booting in a VM is realistic right now.
+- A true cross-distro `bootc switch` / rebase path from Bluefin into this Arch image is **not** done yet.
+
+Why:
+
+- the repo does not yet ship `bootc` in the image
+- it does not yet fully prepare the rootfs the way real bootc/ostree images do
+- it therefore cannot yet be treated as a real rebase target the way Bluefin/Universal Blue images are
+
+## What to preserve from Jorge / Bluefin thinking
+
+The user's long-term direction is still coherent:
+
+- image-owned system content should live in the immutable side of the OS
+- mutable machine/user state should survive image changes
+- switching images should preserve `/var` and managed config/state rather than reinstalling everything manually
+
+For this repo, the practical interpretation is:
+
+- first get the VM image path green
+- then introduce real bootc-in-image support
+- then document how `/etc`, `/var`, and user homes should be treated for rebase/switch scenarios
+
+Do **not** jump straight to BuildStream/Dakota here unless the user explicitly pivots the project. The repo and the user's earlier note both point toward "Arch semantics first, bootc delivery second."
+
+## Suggested next documentation work
+
+Once the VM path is verified, add docs covering:
+
+- current state preservation assumptions:
+  - `/usr` image-owned
+  - `/var` mutable
+  - user homes under `/var/home` if/when true bootc prep is adopted
+- why Bluefin-style switching is still blocked today
+- what milestone unlocks it:
+  - bootc binary in image
+  - dracut/bootc module integration
+  - bootc rootfs prep closer to bootcrew
+
+## Files most relevant for the next step
+
+- `build/10-base.sh`
+- `scripts/ci/vm-smoke.sh`
+- `Containerfile`
+- `image/disk.toml`
+- `docs/bootcrew-comparison.md`
+- `docs/technical-status.md`
+- `.github/workflows/build.yml`

--- a/docs/technical-status.md
+++ b/docs/technical-status.md
@@ -1,11 +1,13 @@
 # Technical status: omarchy-bootc POC
 
-_Last updated: 2026-03-23_
+_Last updated: 2026-03-28_
 
 ## Working now (implemented in repo)
 
 - Build scripts are layered and wired from `Containerfile` with explicit boot-critical package lists in `custom/packages/base.packages` (including `dracut` so `lsinitrd` is available for bootc-image-builder manifest generation).
 - Local build/qcow2/run flow is defined in `Justfile` with consistent local image reference defaults.
+- GitHub Actions builds the image, generates a qcow2 via `bootc-image-builder`, boots it in headless QEMU, and performs an SSH-based smoke test.
+- CI smoke runs now retain host/QEMU/guest diagnostics as workflow artifacts (`bootc-image-builder` log, podman load/save logs, QEMU serial log, qcow metadata, guest journal/unit status).
 - A concrete VM login path is configured: `greetd` + `agreety` launching `Hyprland`, with minimal VM graphics/runtime packages (`mesa`, `vulkan-virtio`, `libinput`).
 - A default POC user is explicitly created at image build time: `omarchy`.
 - Root first-boot script seeds starter config and writes `/var/lib/omarchy/.firstboot-done`.
@@ -50,6 +52,6 @@ _Last updated: 2026-03-23_
 6. Verify first-boot completion in VM:
    - `test -f /var/lib/omarchy/.firstboot-done && echo OK`
 
-Next milestone remains unchanged:
+Next milestone:
 
-> Keep qcow2 generation + headless VM smoke checks green in CI, then expand diagnostics and stability coverage.
+> Broaden stability coverage beyond the single headless smoke path, with stronger in-guest assertions and wider host-environment validation.

--- a/scripts/ci/vm-smoke.sh
+++ b/scripts/ci/vm-smoke.sh
@@ -10,10 +10,78 @@ fi
 BIB_IMAGE="${BIB_IMAGE:-quay.io/centos-bootc/bootc-image-builder:latest}"
 SSH_PORT="${SSH_PORT:-2222}"
 QCOW_PATH="output/qcow2/disk.qcow2"
+ARTIFACT_DIR="${CI_ARTIFACT_DIR:-${RUNNER_TEMP:-/tmp}/omarchy-bootc-artifacts}"
 QEMU_PIDFILE="${RUNNER_TEMP:-/tmp}/omarchy-bootc-qemu.pid"
 QEMU_LOG="${RUNNER_TEMP:-/tmp}/omarchy-bootc-qemu.log"
+SSH_OPTS=(
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o ConnectTimeout=3
+    -p "${SSH_PORT}"
+)
+
+mkdir -p "${ARTIFACT_DIR}"
+
+run_guest() {
+    sshpass -p omarchy ssh "${SSH_OPTS[@]}" omarchy@127.0.0.1 "$@"
+}
+
+write_artifact() {
+    local name="${1}"
+    shift
+
+    "$@" >"${ARTIFACT_DIR}/${name}" 2>&1 || true
+}
+
+capture_guest_diagnostics() {
+    if ! run_guest 'echo guest-up' >/dev/null 2>&1; then
+        return
+    fi
+
+    write_artifact guest-uname.txt run_guest 'uname -a'
+    write_artifact guest-id.txt run_guest 'id'
+    write_artifact guest-systemd-failed.txt run_guest 'systemctl --failed --no-pager --full'
+    write_artifact guest-greetd-status.txt run_guest 'systemctl status greetd --no-pager --full'
+    write_artifact guest-sshd-status.txt run_guest 'systemctl status sshd --no-pager --full'
+    write_artifact guest-journal.txt run_guest 'journalctl -b --no-pager'
+    write_artifact guest-firstboot.txt run_guest 'ls -l /var/lib/omarchy /var/lib/omarchy/.firstboot-done'
+    write_artifact guest-home-config.txt run_guest 'find /home/omarchy/.config -maxdepth 2 -mindepth 1 -type d | sort'
+}
+
+capture_host_diagnostics() {
+    if [[ -f "${QEMU_LOG}" ]]; then
+        cp "${QEMU_LOG}" "${ARTIFACT_DIR}/qemu-serial.log"
+    fi
+
+    if [[ -f "${QEMU_PIDFILE}" ]]; then
+        cp "${QEMU_PIDFILE}" "${ARTIFACT_DIR}/qemu.pid"
+    fi
+
+    if [[ -f "${QCOW_PATH}" ]] && command -v qemu-img >/dev/null 2>&1; then
+        write_artifact qcow-info.txt qemu-img info "${QCOW_PATH}"
+    fi
+
+    write_artifact host-date.txt date -u
+    write_artifact host-kernel.txt uname -a
+}
+
+fail() {
+    local message="${1}"
+
+    capture_host_diagnostics
+    capture_guest_diagnostics
+
+    echo "${message}"
+    if [[ -f "${QEMU_LOG}" ]]; then
+        echo "QEMU serial log (tail):"
+        tail -n 200 "${QEMU_LOG}" || true
+    fi
+    echo "Diagnostics written to ${ARTIFACT_DIR}"
+    exit 1
+}
 
 cleanup() {
+    capture_host_diagnostics
     if [[ -f "${QEMU_PIDFILE}" ]]; then
         kill "$(cat "${QEMU_PIDFILE}")" >/dev/null 2>&1 || true
         rm -f "${QEMU_PIDFILE}"
@@ -24,9 +92,22 @@ trap cleanup EXIT
 mkdir -p output
 rm -rf output/qcow2
 
+echo "::group::Preflight boot artifact compatibility inside image"
+podman run --rm "${IMAGE_REF}" bash -lc '
+set -euo pipefail
+kver=$(find /usr/lib/modules -mindepth 1 -maxdepth 1 -type d -printf "%f\n" | sort -V | tail -n1)
+echo "kver=${kver}"
+ls -l /boot/initramfs-*
+ls -l /usr/lib/modules/*/initramfs.img
+lsinitrd -k "${kver}"
+' 2>&1 | tee "${ARTIFACT_DIR}/image-preflight.log"
+echo "::endgroup::"
+
 echo "::group::Prepare rootful image for bootc-image-builder"
-podman image save "${IMAGE_REF}" -o output/image.tar
-sudo podman image load -i output/image.tar
+podman image save "${IMAGE_REF}" -o output/image.tar \
+    2>&1 | tee "${ARTIFACT_DIR}/podman-image-save.log"
+sudo podman image load -i output/image.tar \
+    2>&1 | tee "${ARTIFACT_DIR}/podman-image-load.log"
 rm -f output/image.tar
 echo "::endgroup::"
 
@@ -38,12 +119,12 @@ sudo podman run --rm --privileged --pull=newer --net=host \
     "${BIB_IMAGE}" \
     --type qcow2 \
     --rootfs btrfs \
-    "${IMAGE_REF}"
+    "${IMAGE_REF}" \
+    2>&1 | tee "${ARTIFACT_DIR}/bootc-image-builder.log"
 echo "::endgroup::"
 
 if [[ ! -f "${QCOW_PATH}" ]]; then
-    echo "Expected qcow2 image not found at ${QCOW_PATH}"
-    exit 1
+    fail "Expected qcow2 image not found at ${QCOW_PATH}"
 fi
 
 echo "::group::Boot qcow2 in headless QEMU"
@@ -62,7 +143,7 @@ qemu-system-x86_64 \
     -serial file:"${QEMU_LOG}" \
     -monitor none \
     -drive if=virtio,format=qcow2,file="${QCOW_PATH}" \
-    -netdev user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22 \
+    -netdev user,id=net0,hostfwd=tcp:127.0.0.1:"${SSH_PORT}"-:22 \
     -device virtio-net-pci,netdev=net0 \
     -daemonize \
     -pidfile "${QEMU_PIDFILE}"
@@ -70,22 +151,19 @@ echo "::endgroup::"
 
 echo "::group::Wait for SSH availability"
 for _ in $(seq 1 180); do
-    if sshpass -p omarchy ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 -p "${SSH_PORT}" omarchy@127.0.0.1 'echo ssh-up' >/dev/null 2>&1; then
+    if run_guest 'echo ssh-up' >/dev/null 2>&1; then
         break
     fi
     sleep 2
 done
 
-if ! sshpass -p omarchy ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 -p "${SSH_PORT}" omarchy@127.0.0.1 'echo ssh-up' >/dev/null 2>&1; then
-    echo "SSH did not become available in time."
-    echo "QEMU serial log (tail):"
-    tail -n 200 "${QEMU_LOG}" || true
-    exit 1
+if ! run_guest 'echo ssh-up' >/dev/null 2>&1; then
+    fail "SSH did not become available in time."
 fi
 echo "::endgroup::"
 
 echo "::group::Run in-VM smoke checks"
-sshpass -p omarchy ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p "${SSH_PORT}" omarchy@127.0.0.1 'set -euo pipefail
+run_guest 'set -euo pipefail
 id omarchy
 [[ -f /var/lib/omarchy/.firstboot-done ]]
 systemctl is-active greetd
@@ -93,7 +171,9 @@ systemctl is-active sshd
 [[ -d /home/omarchy/.config/hypr ]]
 [[ -d /home/omarchy/.config/waybar ]]
 [[ -d /home/omarchy/.config/wofi ]]
-[[ -d /home/omarchy/.config/mako ]]'
+[[ -d /home/omarchy/.config/mako ]]' || fail "In-VM smoke checks failed."
 echo "::endgroup::"
 
+capture_host_diagnostics
+capture_guest_diagnostics
 echo "VM smoke test passed."


### PR DESCRIPTION
## Summary
- Add kernel-version compatibility symlinks during image build so `bootc-image-builder` can resolve Arch initramfs paths.
- Harden the VM smoke script with shared SSH helpers, preflight image checks, and retained host/guest/QEMU diagnostics.
- Update CI to upload smoke artifacts and refresh the repo status docs to reflect the improved validation path.

## Testing
- `shellcheck build/10-base.sh build/20-omarchy.sh build/30-services.sh scripts/ci/vm-smoke.sh`
- `just build`
- `just build-qcow2`
- `just run-vm`
- Not run: GitHub Actions workflow execution in CI