### PR TITLE
Adopt native bootc install path for VM builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,18 @@ jobs:
           sudo apt-get install -y qemu-system-x86 qemu-utils sshpass
 
       - name: VM smoke test (headless qemu + ssh)
+        env:
+          CI_ARTIFACT_DIR: ${{ runner.temp }}/vm-smoke-artifacts
         run: |
           ./scripts/ci/vm-smoke.sh "${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
+
+      - name: Upload VM smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vm-smoke-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/vm-smoke-artifacts
+          if-no-files-found: warn
 
       - name: Tag for registry
         run: |

--- a/Containerfile
+++ b/Containerfile
@@ -39,9 +39,14 @@ RUN --mount=type=cache,dst=/var/cache/pacman/pkg,sharing=locked \
 
 # ── Relocate pacman-managed /var content into /usr/lib/sysimage ───────────────
 # Align with bootcrew/arch-bootc to keep /var mutable and /usr image-owned.
-RUN grep "= */var" /etc/pacman.conf | sed "/= *\\/var/s/.*=// ; s/ //" | \
-        xargs -n1 sh -c 'mkdir -p "/usr/lib/sysimage/$(dirname $(echo $1 | sed \"s@/var/@@\"))\" && mv -v \"$1\" \"/usr/lib/sysimage/$(echo \"$1\" | sed \"s@/var/@@\")\"' '' && \
-    sed -i -e "/= *\\/var/ s/^#//" -e "s@= */var@= /usr/lib/sysimage@g" -e "/DownloadUser/d" /etc/pacman.conf
+RUN set -euo pipefail; \
+    awk -F= '/= *\/var/ { gsub(/ /, "", $2); print $2 }' /etc/pacman.conf | \
+    while read -r path; do \
+        dest="/usr/lib/sysimage/${path#/var/}"; \
+        mkdir -p "$(dirname "${dest}")"; \
+        mv -v "${path}" "${dest}"; \
+    done && \
+    sed -i -e '/= *\/var/ s/^#//' -e 's@= */var@= /usr/lib/sysimage@g' -e '/DownloadUser/d' /etc/pacman.conf
 
 # ── Keep full locales/help available and refresh glibc after relocation ───────
 RUN sed -i 's/^[[:space:]]*NoExtract/#&/' /etc/pacman.conf

--- a/Containerfile
+++ b/Containerfile
@@ -6,12 +6,11 @@
 #
 # IMPORTANT STATUS NOTES
 # - This Containerfile targets a technical POC, not production parity.
-# - bootc availability in Arch repositories is assumed here and must be
-#   revalidated periodically.
-# - pacman DB relocation for immutable /usr is based on known bootc/ostree
-#   patterns but should still be validated against real upgrade flows.
-# - bootc-image-builder compatibility is expected for qcow2 output, but only
-#   runtime VM tests should be treated as proof.
+# - bootc is built from upstream source (BOOTC_REF) during the image build.
+# - pacman/sysroot relocation to /usr/lib/sysimage follows bootc/ostree patterns
+#   and should be validated against real upgrade/rebase flows.
+# - qcow2 output is generated via bootc install-to-disk; bootc-image-builder
+#   remains as a fallback helper.
 ###############################################################################
 
 # ── Context stage ─────────────────────────────────────────────────────────────
@@ -28,6 +27,9 @@ COPY systemd /systemd
 # Example: FROM archlinux:base@sha256:<digest>
 FROM archlinux:base
 
+ARG BOOTC_REF="v1.13.0"
+ENV BOOTC_REF=${BOOTC_REF}
+
 # ── Pacman keyring + full system update ───────────────────────────────────────
 # Layer is separate so the package cache can be shared across rebuilds.
 RUN --mount=type=cache,dst=/var/cache/pacman/pkg,sharing=locked \
@@ -35,38 +37,37 @@ RUN --mount=type=cache,dst=/var/cache/pacman/pkg,sharing=locked \
     pacman-key --populate archlinux && \
     pacman -Syu --noconfirm
 
-# ── Relocate pacman DB for immutable-root expectations ────────────────────────
-# bootc/ostree-style systems generally treat /var as mutable state and /usr as
-# image-owned content. Moving pacman DB to /usr/lib/sysimage/pacman is an
-# explicit compatibility assumption for this POC and should be tested during
-# upgrade/rebase validation.
-RUN mkdir -p /usr/lib/sysimage && \
-    cp -a /var/lib/pacman /usr/lib/sysimage/pacman && \
-    rm -rf /var/lib/pacman && \
-    ln -s /usr/lib/sysimage/pacman /var/lib/pacman && \
-    sed -i 's|^#\?DBPath\s*=.*|DBPath      = /usr/lib/sysimage/pacman|' \
-        /etc/pacman.conf
+# ── Relocate pacman-managed /var content into /usr/lib/sysimage ───────────────
+# Align with bootcrew/arch-bootc to keep /var mutable and /usr image-owned.
+RUN grep "= */var" /etc/pacman.conf | sed "/= *\\/var/s/.*=// ; s/ //" | \
+        xargs -n1 sh -c 'mkdir -p "/usr/lib/sysimage/$(dirname $(echo $1 | sed \"s@/var/@@\"))\" && mv -v \"$1\" \"/usr/lib/sysimage/$(echo \"$1\" | sed \"s@/var/@@\")\"' '' && \
+    sed -i -e "/= *\\/var/ s/^#//" -e "s@= */var@= /usr/lib/sysimage@g" -e "/DownloadUser/d" /etc/pacman.conf
+
+# ── Keep full locales/help available and refresh glibc after relocation ───────
+RUN sed -i 's/^[[:space:]]*NoExtract/#&/' /etc/pacman.conf
+RUN --mount=type=tmpfs,dst=/tmp \
+    --mount=type=cache,dst=/usr/lib/sysimage/cache/pacman/pkg,sharing=locked \
+    pacman -Sy glibc --noconfirm
 
 # ── Build-time OS customisation — numbered scripts run in order ───────────────
 # 10-base.sh    core system packages (bootc, networking, containers)
 # 20-omarchy.sh minimal Wayland/Hyprland session baseline for POC credibility
 # 30-services.sh enable / disable systemd services
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
-    --mount=type=cache,dst=/var/cache/pacman/pkg,sharing=locked \
+    --mount=type=cache,dst=/usr/lib/sysimage/cache/pacman/pkg,sharing=locked \
     --mount=type=tmpfs,dst=/tmp \
     bash /ctx/build/10-base.sh
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
-    --mount=type=cache,dst=/var/cache/pacman/pkg,sharing=locked \
+    --mount=type=cache,dst=/usr/lib/sysimage/cache/pacman/pkg,sharing=locked \
     --mount=type=tmpfs,dst=/tmp \
     bash /ctx/build/20-omarchy.sh
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
-    --mount=type=cache,dst=/var/cache/pacman/pkg,sharing=locked \
+    --mount=type=cache,dst=/usr/lib/sysimage/cache/pacman/pkg,sharing=locked \
     --mount=type=tmpfs,dst=/tmp \
     bash /ctx/build/30-services.sh
 
-# ── bootc lint intentionally deferred ────────────────────────────────────────
-# `bootc` is not currently installable from Arch repos in CI for this project,
-# so `bootc container lint` is deferred until bootc delivery on Arch is solved.
-# Current CI goal: keep image build + VM session path green.
+# ── bootc metadata + lint ─────────────────────────────────────────────────────
+LABEL containers.bootc=1
+RUN bootc container lint

--- a/Justfile
+++ b/Justfile
@@ -23,7 +23,8 @@ help:
     just --list --unsorted
     echo
     echo "Notes:"
-    echo "  - build-qcow2 / rebuild-qcow2 use rootful podman and --privileged bootc-image-builder."
+    echo "  - build-qcow2 / rebuild-qcow2 use rootful podman and bootc install-to-disk (composefs)."
+    echo "  - bootc-image-builder fallback remains as build-qcow2-bib / build-raw-bib."
     echo "  - run-vm-* requires /dev/kvm and a local container runtime capable of --privileged."
     echo "  - validate checks tool availability and required repo files before long builds."
 
@@ -60,7 +61,7 @@ validate:
     set -euo pipefail
 
     REQUIRED_TOOLS=(podman just jq)
-    OPTIONAL_TOOLS=(shellcheck shfmt ss)
+    OPTIONAL_TOOLS=(shellcheck shfmt ss qemu-img)
 
     for t in "${REQUIRED_TOOLS[@]}"; do
         if ! command -v "$t" >/dev/null 2>&1; then
@@ -169,7 +170,7 @@ build $target_image=local_image $tag=default_tag: validate
         --tag "${target_image}:${tag}" \
         .
 
-# ── Bootc Image Builder helpers ───────────────────────────────────────────────
+# ── Bootc Image Builder helpers (fallback) ────────────────────────────────────
 
 # Load a locally-built image into rootful podman (needed for BIB)
 [private]
@@ -233,19 +234,85 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
 [private]
 _rebuild-bib $target_image $tag $type $config: (build target_image tag) && (_build-bib target_image tag type config)
 
-# ── VM image targets ──────────────────────────────────────────────────────────
+# ── Bootc native install targets ──────────────────────────────────────────────
 
-# Build a qcow2 VM image (primary target)
+# Build a qcow2 VM image via bootc install-to-disk (default)
 [group('Build Virtual Machine Image')]
-build-qcow2 $target_image=local_image $tag=default_tag: validate && (_build-bib target_image tag "qcow2" "image/disk.toml")
+build-qcow2 $target_image=local_image $tag=default_tag filesystem="btrfs" size="20G": validate && (build target_image tag)
+    #!/usr/bin/env bash
+    set -euo pipefail
 
-# Build a raw VM image
-[group('Build Virtual Machine Image')]
-build-raw $target_image=local_image $tag=default_tag: validate && (_build-bib target_image tag "raw" "image/disk.toml")
+    raw_path="output/raw/disk.raw"
+    mkdir -p "$(dirname "${raw_path}")"
+    if [[ ! -f "${raw_path}" ]]; then
+        if command -v fallocate >/dev/null 2>&1; then
+            fallocate -l "{{ size }}" "${raw_path}"
+        else
+            truncate -s "{{ size }}" "${raw_path}"
+        fi
+    fi
 
-# Rebuild (OCI + qcow2) in one step
+    sudo podman run \
+        --rm --privileged --pid=host \
+        --pull=newer \
+        -v /dev:/dev \
+        -v /var/lib/containers:/var/lib/containers \
+        -v /etc/containers:/etc/containers \
+        -v "$(pwd):/data" \
+        "{{ target_image }}:{{ tag }}" \
+        bootc install to-disk --composefs-backend --via-loopback "/data/${raw_path}" --filesystem "{{ filesystem }}" --wipe --bootloader systemd
+
+    if ! command -v qemu-img >/dev/null 2>&1; then
+        echo "ERROR: qemu-img not found; install qemu-img or use build-raw. Raw image available at ${raw_path}."
+        exit 1
+    fi
+
+    mkdir -p output/qcow2
+    qemu-img convert -O qcow2 "${raw_path}" output/qcow2/disk.qcow2
+
+# Build a raw VM image via bootc install-to-disk
 [group('Build Virtual Machine Image')]
-rebuild-qcow2 $target_image=local_image $tag=default_tag: validate && (_rebuild-bib target_image tag "qcow2" "image/disk.toml")
+build-raw $target_image=local_image $tag=default_tag size="20G": validate && (build target_image tag)
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    raw_path="output/raw/disk.raw"
+    mkdir -p "$(dirname "${raw_path}")"
+    if [[ ! -f "${raw_path}" ]]; then
+        if command -v fallocate >/dev/null 2>&1; then
+            fallocate -l "{{ size }}" "${raw_path}"
+        else
+            truncate -s "{{ size }}" "${raw_path}"
+        fi
+    fi
+
+    sudo podman run \
+        --rm --privileged --pid=host \
+        --pull=newer \
+        -v /dev:/dev \
+        -v /var/lib/containers:/var/lib/containers \
+        -v /etc/containers:/etc/containers \
+        -v "$(pwd):/data" \
+        "{{ target_image }}:{{ tag }}" \
+        bootc install to-disk --composefs-backend --via-loopback "/data/${raw_path}" --filesystem "btrfs" --wipe --bootloader systemd
+
+# Rebuild (OCI + qcow2) in one step using bootc install-to-disk
+[group('Build Virtual Machine Image')]
+rebuild-qcow2 $target_image=local_image $tag=default_tag filesystem="btrfs" size="20G": validate
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just build-qcow2 "{{ target_image }}" "{{ tag }}" "{{ filesystem }}" "{{ size }}"
+
+# ── Bootc Image Builder (legacy) targets ─────────────────────────────────────
+
+[group('Build Virtual Machine Image')]
+build-qcow2-bib $target_image=local_image $tag=default_tag: validate && (_build-bib target_image tag "qcow2" "image/disk.toml")
+
+[group('Build Virtual Machine Image')]
+build-raw-bib $target_image=local_image $tag=default_tag: validate && (_build-bib target_image tag "raw" "image/disk.toml")
+
+[group('Build Virtual Machine Image')]
+rebuild-qcow2-bib $target_image=local_image $tag=default_tag: validate && (_rebuild-bib target_image tag "qcow2" "image/disk.toml")
 
 # ── Run VM ────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ just build-qcow2
 just run-vm
 ```
 
+> Default qcow2 generation uses `bootc install --composefs-backend --via-loopback` and requires host `qemu-img` plus `--privileged` podman. Use `just build-qcow2-bib` if you need the legacy bootc-image-builder path.
+
 ### Login/session path in VM
 
 1. At the `agreety` prompt, log in as:
@@ -86,24 +88,23 @@ just run-vm
 
 ## Boot assumptions / known blockers
 
-The image now includes explicit boot-critical packages (`linux`, `dracut`, `kmod`, `btrfs-progs`) and a minimal VM graphics stack (`mesa`, `vulkan-virtio`, `libinput`).
+The image now includes explicit boot-critical packages (`linux`, `dracut`, `kmod`, `btrfs-progs`) and a minimal VM graphics stack (`mesa`, `vulkan-virtio`, `libinput`). `bootc` is built from source during the image build with dracut drop-ins, and the sysroot is prepared for composefs/ostree (`HOME=/var/home`).
 
 Remaining assumptions to validate in real VM boots:
 
-- `bootc` delivery/integration on Arch is not solved in this repo yet (package is not currently available in CI repos).
-- `bootc-image-builder` relies on `lsinitrd` during manifest/qcow2 generation; this image now provides it via `dracut`.
-- `bootc-image-builder` reliably produces a bootable Arch qcow2 from this image layout.
-- Arch `bootc` package behavior remains compatible with this flow over time.
+- `bootc install to-disk` (used by `just build-qcow2` / CI smoke) remains reliable across host environments; qcow2 conversion requires `qemu-img`.
+- `bootc` lifecycle operations (upgrade/rebase/rollback) on this Arch-based image still need broader validation.
+- `bootc-image-builder` remains available as a fallback path via `just build-qcow2-bib`.
 - Hyprland compositor behavior in a virtualized GPU environment is host/hypervisor dependent.
 
-See `docs/bootc-delivery-options.md` for current Arch bootc delivery options and the recommended path forward.
-See `docs/bootcrew-comparison.md` for how bootcrew’s Arch bootc images differ and the minimal next step to align.
+See `docs/bootc-delivery-options.md` for current Arch bootc delivery options and the recommended path forward (now implemented via source build).
+See `docs/bootcrew-comparison.md` for how bootcrew’s Arch bootc images differ and what remains to align.
 
 ## Notes
 
 - This remains a technical POC for an Omarchy-style Arch image.
-- bootc delivery/integration on Arch is currently deferred until a real package/source path is validated.
-- Immediate objective is to keep the image building while preserving the first VM login/session path.
+- bootc is shipped from source inside the image; keep validating the bootc/composefs flow over time.
+- Immediate objective is to keep the image building while preserving the first VM login/session path and the bootc install-to-disk smoke path.
 - Desktop defaults are now intentionally Omarchy-inspired but trimmed to the current package set and no-AUR policy.
 - See `docs/technical-status.md` for what is working, what is assumed, and what is deferred.
 - Current CI focus: keep image build + headless VM smoke validation green.

--- a/build/10-base.sh
+++ b/build/10-base.sh
@@ -10,6 +10,9 @@
 
 set -eoux pipefail
 
+BOOTC_REPO="${BOOTC_REPO:-https://github.com/bootc-dev/bootc.git}"
+BOOTC_REF="${BOOTC_REF:-v1.13.0}"
+
 echo "::group:: Install base packages"
 
 # Read package list — strip comments and blank lines
@@ -18,6 +21,68 @@ mapfile -t BASE_PKGS < <(grep -v '^#' /ctx/custom/packages/base.packages | grep 
 if [[ ${#BASE_PKGS[@]} -gt 0 ]]; then
     pacman -S --noconfirm --needed "${BASE_PKGS[@]}"
 fi
+
+echo "::endgroup::"
+
+echo "::group:: Build bootc from source"
+
+pacman -S --noconfirm --needed make git rust go-md2man
+
+TMP_BOOTC=$(mktemp -d /tmp/bootc.XXXXXX)
+git clone --filter=blob:none --branch "${BOOTC_REF}" --depth 1 "${BOOTC_REPO}" "${TMP_BOOTC}"
+make -C "${TMP_BOOTC}" bin install-all
+
+cat > /usr/lib/dracut/dracut.conf.d/30-omarchy-bootc-module.conf <<'EOT'
+systemdsystemconfdir=/etc/systemd/system
+systemdsystemunitdir=/usr/lib/systemd/system
+EOT
+
+cat > /usr/lib/dracut/dracut.conf.d/30-omarchy-bootc.conf <<'EOT'
+reproducible=yes
+hostonly=no
+compress=zstd
+add_dracutmodules+=" ostree bootc "
+EOT
+
+dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v -E "*.img" | tail -n 1)/initramfs.img"
+
+pacman -Rns --noconfirm make git rust go-md2man || true
+pacman -S --clean --noconfirm
+
+rm -rf "${TMP_BOOTC}"
+
+echo "::endgroup::"
+
+echo "::group:: Prepare bootc sysroot"
+
+sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd"
+
+rm -rf /boot /home /root /usr/local /srv /opt /mnt /var /usr/lib/sysimage/log /usr/lib/sysimage/cache/pacman/pkg
+mkdir -p /sysroot /boot /usr/lib/ostree /var /var/lib
+ln -sT sysroot/ostree /ostree
+ln -sT var/roothome /root
+ln -sT var/srv /srv
+ln -sT var/opt /opt
+ln -sT var/mnt /mnt
+ln -sT var/home /home
+ln -sT ../var/usrlocal /usr/local
+
+cat > /usr/lib/tmpfiles.d/bootc-base-dirs.conf <<'EOT'
+d /var/opt 0755 root root -
+d /var/home 0755 root root -
+d /var/mnt 0755 root root -
+d /var/srv 0755 root root -
+d /var/usrlocal 0755 root root -
+d /var/roothome 0700 root root -
+d /run/media 0755 root root -
+EOT
+
+cat > /usr/lib/ostree/prepare-root.conf <<'EOT'
+[composefs]
+enabled = yes
+[sysroot]
+readonly = true
+EOT
 
 echo "::endgroup::"
 

--- a/build/10-base.sh
+++ b/build/10-base.sh
@@ -44,7 +44,12 @@ compress=zstd
 add_dracutmodules+=" ostree bootc "
 EOT
 
-dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v -E "*.img" | tail -n 1)/initramfs.img"
+latest_kver="$(
+    find /usr/lib/modules -mindepth 1 -maxdepth 1 -type d -printf '%f\n' \
+        | sort -V \
+        | tail -n 1
+)"
+dracut --force "/usr/lib/modules/${latest_kver}/initramfs.img"
 
 pacman -Rns --noconfirm make git rust go-md2man || true
 pacman -S --clean --noconfirm
@@ -57,7 +62,20 @@ echo "::group:: Prepare bootc sysroot"
 
 sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd"
 
-rm -rf /boot /home /root /usr/local /srv /opt /mnt /var /usr/lib/sysimage/log /usr/lib/sysimage/cache/pacman/pkg
+cleanup_paths=(
+    /boot
+    /home
+    /root
+    /usr/local
+    /srv
+    /opt
+    /mnt
+    /var
+    /usr/lib/sysimage/log
+)
+for path in "${cleanup_paths[@]}"; do
+    rm -rf -- "${path}"
+done
 mkdir -p /sysroot /boot /usr/lib/ostree /var /var/lib
 ln -sT sysroot/ostree /ostree
 ln -sT var/roothome /root

--- a/build/README.md
+++ b/build/README.md
@@ -13,5 +13,4 @@ Packages are declared in `custom/packages/`.
 This remains a technical POC focused on a first credible VM boot/login path,
 not full Omarchy parity.
 
-
-Note: `bootc` package installation is currently deferred because CI Arch repos do not currently resolve it for this project.
+Note: `bootc` is built from source inside `10-base.sh` (mirroring bootcrew) and dracut is rebuilt with the `bootc` module enabled; the sysroot is prepared for composefs/ostree layout with `/var` as the mutable prefix.

--- a/custom/packages/base.packages
+++ b/custom/packages/base.packages
@@ -2,18 +2,20 @@
 # One package name per line. Lines starting with # and blank lines are ignored.
 # Installed by build/10-base.sh using pacman.
 
-# ── bootc status ─────────────────────────────────────────────────────────────
-# bootc package is intentionally NOT installed here right now because current
-# Arch repos in CI do not provide a resolvable `bootc` package.
-#
-# ── Boot-critical runtime packages for VM images ─────────────────────────────
-# These are intentionally minimal for first qcow2 bootability.
-# dracut is used so lsinitrd is present for bootc-image-builder manifest generation.
+# ── Boot-critical runtime packages for bootc/composefs sysroot ───────────────
+# bootc itself is built from source during the image build (see build/10-base.sh).
+base
 linux
+linux-firmware
 dracut
 kmod
+cpio
 btrfs-progs
-linux-firmware
+e2fsprogs
+xfsprogs
+dosfstools
+ostree
+skopeo
 
 # ── Networking ────────────────────────────────────────────────────────────────
 networkmanager
@@ -23,9 +25,13 @@ openssh
 sudo
 bash
 vim
+shadow
 
 # ── Container tooling ─────────────────────────────────────────────────────────
 # Explicit runtime provider keeps pacman non-interactive in CI when installing
 # podman (avoids provider prompt for oci-runtime).
 crun
 podman
+dbus
+dbus-glib
+glib2

--- a/docs/bootc-delivery-options.md
+++ b/docs/bootc-delivery-options.md
@@ -4,9 +4,9 @@ _Last updated: 2026-03-23_
 
 ## Current state
 
-- bootc is intentionally omitted from the base package list because Arch repos in CI have not provided a resolvable package (`custom/packages/base.packages`).
-- Container builds defer `bootc container lint` for the same reason (`Containerfile` notes).
-- The image path relies on `bootc-image-builder` (CentOS container) to create qcow2 output; the Arch image itself does not yet include bootc.
+- bootc is built from upstream source during the image build (pinned via `BOOTC_REF`, default `v1.13.0`), and `bootc container lint` now runs in the image build.
+- Pacman/sysroot layout is shifted under `/usr/lib/sysimage`, composefs/ostree is enabled, and dracut is rebuilt with the bootc module.
+- qcow2/raw output is produced via `bootc install --composefs-backend --via-loopback`; bootc-image-builder remains available as a fallback (`build-qcow2-bib`).
 
 ## Candidate delivery options
 
@@ -42,14 +42,14 @@ _Last updated: 2026-03-23_
 
 ## Recommendation
 
-- Prepare a self-maintained pacman repo path for bootc, built from a pinned PKGBUILD we track in-repo. Consume it via an opt-in pacman repo stanza only after the package is proven to build and pass minimal `bootc container lint` in CI.
+- Continue pinning upstream bootc via `BOOTC_REF`, keep `bootc container lint` green, and consider moving to a self-maintained pacman repo once the source build is stable in CI.
 
 ## Do not do yet
 
-- Do not add bootc to `custom/packages/base.packages` or enable `bootc container lint` in `Containerfile`.
 - Do not switch the image build to a third-party binary repo by default.
 - Do not add installer/BuildStream work in this spike.
+- Do not assume Arch will ship a bootc package soon; keep the pinned source build path maintained.
 
 ## Smallest next step (safe experiment)
 
-- Mirror a vetted PKGBUILD (start with `bootc` or `bootc-git` from AUR) into a scratch branch, run `makepkg` in CI to produce a signed package artifact, and publish it to a temporary repo directory. Do not wire the main image build to that repo yet; use the artifact only to validate bootc runs and `bootc container lint` in CI.
+- Add automated coverage for `bootc` upgrade/rebase/rollback on the composefs sysroot and evaluate whether a self-maintained pacman package would simplify long-term maintenance.

--- a/docs/bootcrew-comparison.md
+++ b/docs/bootcrew-comparison.md
@@ -12,18 +12,20 @@ Summary of how bootcrew ships real `bootc` on Arch and how this repository diffe
 
 ## How omarchy-bootc differs today
 
-- bootc is intentionally not installed; the image relies on `bootc-image-builder` (CentOS container) to emit qcow2 output, not on `bootc install` from within the Arch image.
-- Pacman DB is relocated only (to `/usr/lib/sysimage/pacman`); the rest of `/var` remains in place and composefs/ostree prep is not applied.
-- Initramfs is not rebuilt with bootc modules; no dracut drop-ins for bootc are present.
-- The image omits `bootc container lint` and the `containers.bootc=1` label because bootc itself is absent.
-- Boot assumptions lean on bootc-image-builder (lsinitrd via `dracut` package) rather than the bootc-in-image workflow bootcrew uses.
+- bootc is built from source in-image (default `BOOTC_REF=v1.13.0`), dracut drop-ins add the `bootc` module, and initramfs is rebuilt during the image build.
+- Sysroot/pacman layout matches bootcrew: `/usr/lib/sysimage` pacman paths, `/var` as mutable prefix, `HOME=/var/home`, composefs enabled via `prepare-root.conf`, tmpfiles for mutable dirs.
+- `bootc container lint` and `containers.bootc=1` label are now applied.
+- Primary qcow2 path uses `bootc install --composefs-backend --via-loopback` (raw then qcow2 via `qemu-img`); legacy bootc-image-builder remains as `build-qcow2-bib`.
+- Omarchy desktop/session customizations remain on top of the bootcrew-aligned bootc base.
 
 ## What blocks real bootc integration here
 
-- No bootc binary/package in the Arch image, so we cannot run `bootc container lint` or `bootc install` from inside the image.
-- No bootc-aware initramfs (dracut module) or composefs/ostree root prep, which bootcrew applies to make the image bootc-ready.
-- Image metadata/labels and bootc lifecycle checks are missing because bootc is absent.
+- Coverage for bootc lifecycle (upgrade/rebase/rollback) on Arch remains missing.
+- Host dependency on `qemu-img` for qcow2 conversion after `bootc install` (raw output is first-class).
+- Validation across host/container runtimes for the new bootc install-to-disk path still needs to be broadened.
 
 ## Smallest next step to align safely
 
-- Introduce an optional, pinned bootc-from-source builder stage (mirroring `bootcrew/mono`’s builder+system split) that can be toggled on for experiments without altering the default image flow. Pair it with gated dracut drop-ins to add the bootc module when bootc is present. Keep the current bootc-less default until the source build is validated in CI.
+- Add automated bootc lifecycle tests (rebase/rollback) against the composefs/ostree sysroot.
+- Track and periodically refresh the pinned `BOOTC_REF` while keeping lint/install runs green.
+- Decide when to retire the bootc-image-builder fallback once the native bootc install path is stable in CI.

--- a/docs/technical-status.md
+++ b/docs/technical-status.md
@@ -4,8 +4,11 @@ _Last updated: 2026-03-23_
 
 ## Working now (implemented in repo)
 
-- Build scripts are layered and wired from `Containerfile` with explicit boot-critical package lists in `custom/packages/base.packages` (including `dracut` so `lsinitrd` is available for bootc-image-builder manifest generation).
+- Build scripts are layered and wired from `Containerfile` with explicit boot-critical package lists in `custom/packages/base.packages` (including `dracut` for bootc initramfs rebuilds and BIB fallback if needed).
+- bootc is built from source during image build (default `BOOTC_REF=v1.13.0`), dracut is rebuilt with the `bootc` module, and bootc container metadata/lint are applied.
+- Sysroot is prepared for bootc/composefs (`HOME=/var/home`, `/usr/lib/sysimage` pacman paths, tmpfiles for mutable dirs, `prepare-root.conf` enabling composefs/readonly sysroot).
 - Local build/qcow2/run flow is defined in `Justfile` with consistent local image reference defaults.
+- Native `bootc install to-disk` path emits raw/qcow2 images via `just build-qcow2`; legacy bootc-image-builder targets remain available as `build-qcow2-bib` / `build-raw-bib`.
 - A concrete VM login path is configured: `greetd` + `agreety` launching `Hyprland`, with minimal VM graphics/runtime packages (`mesa`, `vulkan-virtio`, `libinput`).
 - A default POC user is explicitly created at image build time: `omarchy`.
 - Root first-boot script seeds starter config and writes `/var/lib/omarchy/.firstboot-done`.
@@ -18,11 +21,11 @@ _Last updated: 2026-03-23_
 
 ## Still unverified (needs broader VM validation)
 
-- bootc delivery/integration on Arch is currently not solved in this repository.
+- bootc lifecycle checks (upgrade/rebase/rollback) on this Arch-based image.
+- Reliability of `bootc install --composefs-backend --via-loopback` across host/container runtimes; qcow2 conversion relies on host `qemu-img`.
 - End-to-end VM reliability across host environments.
 - Desktop session quality/stability beyond first login.
-- bootc lifecycle checks (rebase/rollback) on this Arch-based image (blocked until bootc delivery on Arch is solved here).
-- Long-term assumptions around pacman DB relocation and bootc package behavior in Arch repos.
+- Long-term assumptions around pacman DB relocation and bootc source build behavior over time.
 
 ## Deferred intentionally
 

--- a/scripts/ci/vm-smoke.sh
+++ b/scripts/ci/vm-smoke.sh
@@ -7,11 +7,16 @@ if [[ -z "${IMAGE_REF}" ]]; then
     exit 1
 fi
 
-BIB_IMAGE="${BIB_IMAGE:-quay.io/centos-bootc/bootc-image-builder:latest}"
 SSH_PORT="${SSH_PORT:-2222}"
 QCOW_PATH="output/qcow2/disk.qcow2"
+RAW_PATH="output/raw/disk.raw"
 QEMU_PIDFILE="${RUNNER_TEMP:-/tmp}/omarchy-bootc-qemu.pid"
 QEMU_LOG="${RUNNER_TEMP:-/tmp}/omarchy-bootc-qemu.log"
+
+if ! command -v qemu-img >/dev/null 2>&1; then
+    echo "qemu-img is required for bootc install-to-disk smoke tests."
+    exit 1
+fi
 
 cleanup() {
     if [[ -f "${QEMU_PIDFILE}" ]]; then
@@ -22,23 +27,31 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p output
-rm -rf output/qcow2
+rm -rf output/qcow2 output/raw
 
-echo "::group::Prepare rootful image for bootc-image-builder"
+echo "::group::Prepare rootful image for bootc install"
 podman image save "${IMAGE_REF}" -o output/image.tar
 sudo podman image load -i output/image.tar
 rm -f output/image.tar
 echo "::endgroup::"
 
-echo "::group::Generate qcow2 from container image"
-sudo podman run --rm --privileged --pull=newer --net=host \
-    -v "${PWD}/image/disk.toml:/config.toml:ro" \
-    -v "${PWD}/output:/output" \
-    -v /var/lib/containers/storage:/var/lib/containers/storage \
-    "${BIB_IMAGE}" \
-    --type qcow2 \
-    --rootfs btrfs \
-    "${IMAGE_REF}"
+echo "::group::Generate qcow2 via bootc install-to-disk"
+mkdir -p "$(dirname "${RAW_PATH}")" "$(dirname "${QCOW_PATH}")"
+if command -v fallocate >/dev/null 2>&1; then
+    fallocate -l 20G "${RAW_PATH}"
+else
+    truncate -s 20G "${RAW_PATH}"
+fi
+
+sudo podman run --rm --privileged --pid=host --pull=newer \
+    -v /dev:/dev \
+    -v /var/lib/containers:/var/lib/containers \
+    -v /etc/containers:/etc/containers \
+    -v "${PWD}:/data" \
+    "${IMAGE_REF}" \
+    bootc install to-disk --composefs-backend --via-loopback "/data/${RAW_PATH}" --filesystem btrfs --wipe --bootloader systemd
+
+qemu-img convert -O qcow2 "${RAW_PATH}" "${QCOW_PATH}"
 echo "::endgroup::"
 
 if [[ ! -f "${QCOW_PATH}" ]]; then

--- a/scripts/ci/vm-smoke.sh
+++ b/scripts/ci/vm-smoke.sh
@@ -10,15 +10,87 @@ fi
 SSH_PORT="${SSH_PORT:-2222}"
 QCOW_PATH="output/qcow2/disk.qcow2"
 RAW_PATH="output/raw/disk.raw"
+ARTIFACT_DIR="${CI_ARTIFACT_DIR:-${RUNNER_TEMP:-/tmp}/omarchy-bootc-artifacts}"
 QEMU_PIDFILE="${RUNNER_TEMP:-/tmp}/omarchy-bootc-qemu.pid"
 QEMU_LOG="${RUNNER_TEMP:-/tmp}/omarchy-bootc-qemu.log"
+SSH_OPTS=(
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o ConnectTimeout=3
+    -p "${SSH_PORT}"
+)
 
 if ! command -v qemu-img >/dev/null 2>&1; then
     echo "qemu-img is required for bootc install-to-disk smoke tests."
     exit 1
 fi
 
+mkdir -p "${ARTIFACT_DIR}"
+
+run_guest() {
+    sshpass -p omarchy ssh "${SSH_OPTS[@]}" omarchy@127.0.0.1 "$@"
+}
+
+write_artifact() {
+    local name="${1}"
+    shift
+
+    "$@" >"${ARTIFACT_DIR}/${name}" 2>&1 || true
+}
+
+capture_guest_diagnostics() {
+    if ! run_guest 'echo guest-up' >/dev/null 2>&1; then
+        return
+    fi
+
+    write_artifact guest-uname.txt run_guest 'uname -a'
+    write_artifact guest-id.txt run_guest 'id'
+    write_artifact guest-systemd-failed.txt run_guest 'systemctl --failed --no-pager --full'
+    write_artifact guest-greetd-status.txt run_guest 'systemctl status greetd --no-pager --full'
+    write_artifact guest-sshd-status.txt run_guest 'systemctl status sshd --no-pager --full'
+    write_artifact guest-journal.txt run_guest 'journalctl -b --no-pager'
+    write_artifact guest-firstboot.txt run_guest 'ls -l /var/lib/omarchy /var/lib/omarchy/.firstboot-done'
+    write_artifact guest-home-config.txt run_guest 'find /home/omarchy/.config -maxdepth 2 -mindepth 1 -type d | sort'
+}
+
+capture_host_diagnostics() {
+    if [[ -f "${QEMU_LOG}" ]]; then
+        cp "${QEMU_LOG}" "${ARTIFACT_DIR}/qemu-serial.log"
+    fi
+
+    if [[ -f "${QEMU_PIDFILE}" ]]; then
+        cp "${QEMU_PIDFILE}" "${ARTIFACT_DIR}/qemu.pid"
+    fi
+
+    if [[ -f "${RAW_PATH}" ]] && command -v qemu-img >/dev/null 2>&1; then
+        write_artifact raw-info.txt qemu-img info "${RAW_PATH}"
+    fi
+
+    if [[ -f "${QCOW_PATH}" ]] && command -v qemu-img >/dev/null 2>&1; then
+        write_artifact qcow-info.txt qemu-img info "${QCOW_PATH}"
+    fi
+
+    write_artifact host-date.txt date -u
+    write_artifact host-kernel.txt uname -a
+}
+
+fail() {
+    local message="${1}"
+
+    capture_host_diagnostics
+    capture_guest_diagnostics
+
+    echo "${message}"
+    if [[ -f "${QEMU_LOG}" ]]; then
+        echo "QEMU serial log (tail):"
+        tail -n 200 "${QEMU_LOG}" || true
+    fi
+    echo "Diagnostics written to ${ARTIFACT_DIR}"
+    exit 1
+}
+
 cleanup() {
+    capture_host_diagnostics
     if [[ -f "${QEMU_PIDFILE}" ]]; then
         kill "$(cat "${QEMU_PIDFILE}")" >/dev/null 2>&1 || true
         rm -f "${QEMU_PIDFILE}"
@@ -29,9 +101,20 @@ trap cleanup EXIT
 mkdir -p output
 rm -rf output/qcow2 output/raw
 
+echo "::group::Preflight bootc image state"
+podman run --rm "${IMAGE_REF}" bash -lc '
+set -euo pipefail
+echo "bootc=$(bootc --version | head -n1)"
+bootc container lint
+find /usr/lib/modules -mindepth 1 -maxdepth 2 \( -name initramfs.img -o -name vmlinuz \) | sort
+' 2>&1 | tee "${ARTIFACT_DIR}/image-preflight.log"
+echo "::endgroup::"
+
 echo "::group::Prepare rootful image for bootc install"
-podman image save "${IMAGE_REF}" -o output/image.tar
-sudo podman image load -i output/image.tar
+podman image save "${IMAGE_REF}" -o output/image.tar \
+    2>&1 | tee "${ARTIFACT_DIR}/podman-image-save.log"
+sudo podman image load -i output/image.tar \
+    2>&1 | tee "${ARTIFACT_DIR}/podman-image-load.log"
 rm -f output/image.tar
 echo "::endgroup::"
 
@@ -49,14 +132,14 @@ sudo podman run --rm --privileged --pid=host --pull=newer \
     -v /etc/containers:/etc/containers \
     -v "${PWD}:/data" \
     "${IMAGE_REF}" \
-    bootc install to-disk --composefs-backend --via-loopback "/data/${RAW_PATH}" --filesystem btrfs --wipe --bootloader systemd
+    bootc install to-disk --composefs-backend --via-loopback "/data/${RAW_PATH}" --filesystem btrfs --wipe --bootloader systemd \
+    2>&1 | tee "${ARTIFACT_DIR}/bootc-install.log"
 
 qemu-img convert -O qcow2 "${RAW_PATH}" "${QCOW_PATH}"
 echo "::endgroup::"
 
 if [[ ! -f "${QCOW_PATH}" ]]; then
-    echo "Expected qcow2 image not found at ${QCOW_PATH}"
-    exit 1
+    fail "Expected qcow2 image not found at ${QCOW_PATH}"
 fi
 
 echo "::group::Boot qcow2 in headless QEMU"
@@ -75,7 +158,7 @@ qemu-system-x86_64 \
     -serial file:"${QEMU_LOG}" \
     -monitor none \
     -drive if=virtio,format=qcow2,file="${QCOW_PATH}" \
-    -netdev user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22 \
+    -netdev user,id=net0,hostfwd=tcp:127.0.0.1:"${SSH_PORT}"-:22 \
     -device virtio-net-pci,netdev=net0 \
     -daemonize \
     -pidfile "${QEMU_PIDFILE}"
@@ -83,22 +166,19 @@ echo "::endgroup::"
 
 echo "::group::Wait for SSH availability"
 for _ in $(seq 1 180); do
-    if sshpass -p omarchy ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 -p "${SSH_PORT}" omarchy@127.0.0.1 'echo ssh-up' >/dev/null 2>&1; then
+    if run_guest 'echo ssh-up' >/dev/null 2>&1; then
         break
     fi
     sleep 2
 done
 
-if ! sshpass -p omarchy ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 -p "${SSH_PORT}" omarchy@127.0.0.1 'echo ssh-up' >/dev/null 2>&1; then
-    echo "SSH did not become available in time."
-    echo "QEMU serial log (tail):"
-    tail -n 200 "${QEMU_LOG}" || true
-    exit 1
+if ! run_guest 'echo ssh-up' >/dev/null 2>&1; then
+    fail "SSH did not become available in time."
 fi
 echo "::endgroup::"
 
 echo "::group::Run in-VM smoke checks"
-sshpass -p omarchy ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p "${SSH_PORT}" omarchy@127.0.0.1 'set -euo pipefail
+run_guest 'set -euo pipefail
 id omarchy
 [[ -f /var/lib/omarchy/.firstboot-done ]]
 systemctl is-active greetd
@@ -106,7 +186,9 @@ systemctl is-active sshd
 [[ -d /home/omarchy/.config/hypr ]]
 [[ -d /home/omarchy/.config/waybar ]]
 [[ -d /home/omarchy/.config/wofi ]]
-[[ -d /home/omarchy/.config/mako ]]'
+[[ -d /home/omarchy/.config/mako ]]' || fail "In-VM smoke checks failed."
 echo "::endgroup::"
 
+capture_host_diagnostics
+capture_guest_diagnostics
 echo "VM smoke test passed."


### PR DESCRIPTION
## Summary
- Builds `bootc` from source during the image build and enables bootc metadata/lint in the Containerfile.
- Switches the primary qcow2 workflow to `bootc install --composefs-backend --via-loopback`, with legacy bootc-image-builder targets kept as fallback.
- Prepares the sysroot and pacman layout for bootc/composefs, including `/usr/lib/sysimage`, dracut bootc modules, and mutable `/var` paths.
- Expands CI VM smoke testing to capture diagnostics and upload artifacts on failure or completion.
- Updates docs, README, and package lists to reflect the new bootc-native flow.

## Testing
- Not run.
- CI VM smoke path now checks `bootc container lint`, builds a raw image, converts to qcow2 with `qemu-img`, and boots it in headless QEMU.
- The workflow uploads VM smoke artifacts from `${{ runner.temp }}/vm-smoke-artifacts` for post-failure inspection.