### PR TITLE
[codex] Fix rootful bootc install handoff

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+    "name": "bluefin-devcontainer",
+    "image": "ghcr.io/ublue-os/devcontainer:latest"
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install VM smoke test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y qemu-system-x86 qemu-utils sshpass
+          sudo apt-get install -y qemu-system-x86 qemu-utils sshpass systemd-container
 
       - name: VM smoke test (headless qemu + ssh)
         env:

--- a/Justfile
+++ b/Justfile
@@ -61,7 +61,7 @@ validate:
     set -euo pipefail
 
     REQUIRED_TOOLS=(podman just jq)
-    OPTIONAL_TOOLS=(shellcheck shfmt ss qemu-img)
+    OPTIONAL_TOOLS=(shellcheck shfmt ss qemu-img machinectl)
 
     for t in "${REQUIRED_TOOLS[@]}"; do
         if ! command -v "$t" >/dev/null 2>&1; then
@@ -193,6 +193,10 @@ _rootful_load_image $target_image=local_image $tag=default_tag:
     if [[ $return_code -eq 0 ]]; then
         ID=$(just sudoif podman images --filter reference="${target_image}:${tag}" --format "{{{{.ID}}}}")
         if [[ "$ID" != "$USER_IMG_ID" ]]; then
+            if ! command -v machinectl >/dev/null 2>&1; then
+                echo "ERROR: machinectl is required for podman image scp when copying images into rootful podman."
+                exit 1
+            fi
             COPYTMP=$(mktemp -p "${PWD}" -d -t _build_podman_scp.XXXXXXXXXX)
             just sudoif TMPDIR="${COPYTMP}" podman image scp \
                 "${UID}@localhost::${target_image}:${tag}" \

--- a/Justfile
+++ b/Justfile
@@ -1,11 +1,11 @@
-export image_name    := env("IMAGE_NAME",    "omarchy-bootc")
-export default_tag   := env("DEFAULT_TAG",   "stable")
-export bib_image     := env("BIB_IMAGE",     "quay.io/centos-bootc/bootc-image-builder:latest")
-export local_image   := env("LOCAL_IMAGE",  "localhost/" + image_name)
+export image_name := env("IMAGE_NAME", "omarchy-bootc")
+export default_tag := env("DEFAULT_TAG", "stable")
+export bib_image := env("BIB_IMAGE", "quay.io/centos-bootc/bootc-image-builder:latest")
+export local_image := env("LOCAL_IMAGE", "localhost/" + image_name)
 
-alias build-vm   := build-qcow2
+alias build-vm := build-qcow2
 alias rebuild-vm := rebuild-qcow2
-alias run-vm     := run-vm-qcow2
+alias run-vm := run-vm-qcow2
 
 [private]
 default:
@@ -151,8 +151,8 @@ sudoif command *args:
     sudoif {{ command }} {{ args }}
 
 # ── Container image build ─────────────────────────────────────────────────────
-
 # Build the OCI container image locally with podman
+
 # Usage: just build [target_image] [tag]
 [group('Build')]
 build $target_image=local_image $tag=default_tag: validate
@@ -242,6 +242,8 @@ build-qcow2 $target_image=local_image $tag=default_tag filesystem="btrfs" size="
     #!/usr/bin/env bash
     set -euo pipefail
 
+    just _rootful_load_image "{{ target_image }}" "{{ tag }}"
+
     raw_path="output/raw/disk.raw"
     mkdir -p "$(dirname "${raw_path}")"
     if [[ ! -f "${raw_path}" ]]; then
@@ -275,6 +277,8 @@ build-qcow2 $target_image=local_image $tag=default_tag filesystem="btrfs" size="
 build-raw $target_image=local_image $tag=default_tag size="20G": validate && (build target_image tag)
     #!/usr/bin/env bash
     set -euo pipefail
+
+    just _rootful_load_image "{{ target_image }}" "{{ tag }}"
 
     raw_path="output/raw/disk.raw"
     mkdir -p "$(dirname "${raw_path}")"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ just run-vm
 ```
 
 > Default qcow2 generation uses `bootc install --composefs-backend --via-loopback` and requires host `qemu-img` plus `--privileged` podman. Use `just build-qcow2-bib` if you need the legacy bootc-image-builder path.
+> The native disk-image recipes automatically copy the locally-built image into rootful podman before `bootc install to-disk`, which is required when the build itself ran rootless.
 
 ### Login/session path in VM
 
@@ -92,7 +93,7 @@ The image now includes explicit boot-critical packages (`linux`, `dracut`, `kmod
 
 Remaining assumptions to validate in real VM boots:
 
-- `bootc install to-disk` (used by `just build-qcow2` / CI smoke) remains reliable across host environments; qcow2 conversion requires `qemu-img`.
+- `bootc install to-disk` (used by `just build-qcow2` / CI smoke) remains reliable across host environments once the rootful image handoff is in place; qcow2 conversion requires `qemu-img`.
 - `bootc` lifecycle operations (upgrade/rebase/rollback) on this Arch-based image still need broader validation.
 - `bootc-image-builder` remains available as a fallback path via `just build-qcow2-bib`.
 - Hyprland compositor behavior in a virtualized GPU environment is host/hypervisor dependent.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ omarchy-bootc/
 - `podman`
 - `just`
 - `jq`
+- `machinectl` (required when the native disk-image recipes need to copy a rootless-built image into rootful podman)
 - `sudo` (for rootful bootc-image-builder)
 - `/dev/kvm` for practical VM boot testing
 

--- a/docs/technical-status.md
+++ b/docs/technical-status.md
@@ -10,6 +10,7 @@ _Last updated: 2026-04-19_
 - Local build/qcow2/run flow is defined in `Justfile` with consistent local image reference defaults.
 - Native `bootc install to-disk` path emits raw/qcow2 images via `just build-qcow2`; legacy bootc-image-builder targets remain available as `build-qcow2-bib` / `build-raw-bib`.
 - Rootful/rootless image handoff is now explicit for the native disk-image path: `Justfile` and `scripts/ci/vm-smoke.sh` copy the already-built image into rootful podman before running `bootc install to-disk`.
+- CI installs `systemd-container` so `machinectl` is available for the `podman image scp` handoff used by the smoke path.
 - A concrete VM login path is configured: `greetd` + `agreety` launching `Hyprland`, with minimal VM graphics/runtime packages (`mesa`, `vulkan-virtio`, `libinput`).
 - A default POC user is explicitly created at image build time: `omarchy`.
 - Root first-boot script seeds starter config and writes `/var/lib/omarchy/.firstboot-done`.

--- a/docs/technical-status.md
+++ b/docs/technical-status.md
@@ -1,6 +1,6 @@
 # Technical status: omarchy-bootc POC
 
-_Last updated: 2026-03-23_
+_Last updated: 2026-04-19_
 
 ## Working now (implemented in repo)
 
@@ -9,6 +9,7 @@ _Last updated: 2026-03-23_
 - Sysroot is prepared for bootc/composefs (`HOME=/var/home`, `/usr/lib/sysimage` pacman paths, tmpfiles for mutable dirs, `prepare-root.conf` enabling composefs/readonly sysroot).
 - Local build/qcow2/run flow is defined in `Justfile` with consistent local image reference defaults.
 - Native `bootc install to-disk` path emits raw/qcow2 images via `just build-qcow2`; legacy bootc-image-builder targets remain available as `build-qcow2-bib` / `build-raw-bib`.
+- Rootful/rootless image handoff is now explicit for the native disk-image path: `Justfile` and `scripts/ci/vm-smoke.sh` copy the already-built image into rootful podman before running `bootc install to-disk`.
 - A concrete VM login path is configured: `greetd` + `agreety` launching `Hyprland`, with minimal VM graphics/runtime packages (`mesa`, `vulkan-virtio`, `libinput`).
 - A default POC user is explicitly created at image build time: `omarchy`.
 - Root first-boot script seeds starter config and writes `/var/lib/omarchy/.firstboot-done`.
@@ -19,9 +20,16 @@ _Last updated: 2026-03-23_
   - Mako notification defaults
   - lock/screenshot UX bindings wired to shipped tools (`swaylock`, `grim`, `slurp`, `wl-clipboard`)
 
+## Most recent blocker addressed in repo
+
+- The old PR `#14` failure mode (`image ... is not a bootc image`) was superseded by merged PR `#15`, which added bootc source builds plus `bootc container lint`.
+- The repeated `main` workflow failure after PR `#15` was a different issue: CI copied the image into rootful podman with `podman image save` / `load`, then `bootc install to-disk` failed reopening the image from `containers-storage` with missing config-blob errors.
+- The repo now uses a storage-native rootful copy step (`podman image scp`) for both local native disk-image builds and CI smoke tests.
+
 ## Still unverified (needs broader VM validation)
 
 - bootc lifecycle checks (upgrade/rebase/rollback) on this Arch-based image.
+- End-to-end confirmation of the rootful-image handoff fix in GitHub Actions after a fresh workflow rerun.
 - Reliability of `bootc install --composefs-backend --via-loopback` across host/container runtimes; qcow2 conversion relies on host `qemu-img`.
 - End-to-end VM reliability across host environments.
 - Desktop session quality/stability beyond first login.

--- a/scripts/ci/vm-smoke.sh
+++ b/scripts/ci/vm-smoke.sh
@@ -20,6 +20,30 @@ SSH_OPTS=(
     -p "${SSH_PORT}"
 )
 
+rootful_copy_image() {
+    local image_ref="${1}"
+    local rootless_id=""
+    local rootful_id=""
+    local copy_tmp=""
+
+    rootless_id="$(podman images --filter "reference=${image_ref}" --format '{{.ID}}' | head -n 1)"
+    if [[ -z "${rootless_id}" ]]; then
+        echo "Unable to locate rootless image for ${image_ref}"
+        exit 1
+    fi
+
+    rootful_id="$(sudo podman images --filter "reference=${image_ref}" --format '{{.ID}}' | head -n 1 || true)"
+    if [[ "${rootful_id}" == "${rootless_id}" ]]; then
+        return
+    fi
+
+    copy_tmp="$(mktemp -d -p "${PWD}" -t _build_podman_scp.XXXXXXXXXX)"
+    sudo TMPDIR="${copy_tmp}" podman image scp \
+        "$(id -u)@localhost::${image_ref}" \
+        "root@localhost::${image_ref}"
+    rm -rf "${copy_tmp}"
+}
+
 if ! command -v qemu-img >/dev/null 2>&1; then
     echo "qemu-img is required for bootc install-to-disk smoke tests."
     exit 1
@@ -102,6 +126,9 @@ mkdir -p output
 rm -rf output/qcow2 output/raw
 
 echo "::group::Preflight bootc image state"
+IMAGE_REF="$(podman inspect -t image "${IMAGE_REF}" --format '{{index .RepoTags 0}}')"
+echo "Resolved image ref: ${IMAGE_REF}" | tee "${ARTIFACT_DIR}/image-ref.txt"
+
 podman run --rm "${IMAGE_REF}" bash -lc '
 set -euo pipefail
 echo "bootc=$(bootc --version | head -n1)"
@@ -111,11 +138,8 @@ find /usr/lib/modules -mindepth 1 -maxdepth 2 \( -name initramfs.img -o -name vm
 echo "::endgroup::"
 
 echo "::group::Prepare rootful image for bootc install"
-podman image save "${IMAGE_REF}" -o output/image.tar \
-    2>&1 | tee "${ARTIFACT_DIR}/podman-image-save.log"
-sudo podman image load -i output/image.tar \
-    2>&1 | tee "${ARTIFACT_DIR}/podman-image-load.log"
-rm -f output/image.tar
+rootful_copy_image "${IMAGE_REF}" \
+    2>&1 | tee "${ARTIFACT_DIR}/rootful-image-copy.log"
 echo "::endgroup::"
 
 echo "::group::Generate qcow2 via bootc install-to-disk"

--- a/scripts/ci/vm-smoke.sh
+++ b/scripts/ci/vm-smoke.sh
@@ -26,6 +26,11 @@ rootful_copy_image() {
     local rootful_id=""
     local copy_tmp=""
 
+    if ! command -v machinectl >/dev/null 2>&1; then
+        echo "machinectl is required for podman image scp when copying into rootful podman"
+        exit 1
+    fi
+
     rootless_id="$(podman images --filter "reference=${image_ref}" --format '{{.ID}}' | head -n 1)"
     if [[ -z "${rootless_id}" ]]; then
         echo "Unable to locate rootless image for ${image_ref}"

--- a/scripts/ci/vm-smoke.sh
+++ b/scripts/ci/vm-smoke.sh
@@ -10,6 +10,7 @@ fi
 SSH_PORT="${SSH_PORT:-2222}"
 QCOW_PATH="output/qcow2/disk.qcow2"
 RAW_PATH="output/raw/disk.raw"
+SOURCE_OCI_DIR="output/source-oci"
 ARTIFACT_DIR="${CI_ARTIFACT_DIR:-${RUNNER_TEMP:-/tmp}/omarchy-bootc-artifacts}"
 QEMU_PIDFILE="${RUNNER_TEMP:-/tmp}/omarchy-bootc-qemu.pid"
 QEMU_LOG="${RUNNER_TEMP:-/tmp}/omarchy-bootc-qemu.log"
@@ -128,7 +129,7 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p output
-rm -rf output/qcow2 output/raw
+rm -rf output/qcow2 output/raw "${SOURCE_OCI_DIR}"
 
 echo "::group::Preflight bootc image state"
 IMAGE_REF="$(podman inspect -t image "${IMAGE_REF}" --format '{{index .RepoTags 0}}')"
@@ -147,6 +148,13 @@ rootful_copy_image "${IMAGE_REF}" \
     2>&1 | tee "${ARTIFACT_DIR}/rootful-image-copy.log"
 echo "::endgroup::"
 
+echo "::group::Export explicit install source image"
+podman save --format oci-dir --output "${SOURCE_OCI_DIR}" "${IMAGE_REF}" \
+    2>&1 | tee "${ARTIFACT_DIR}/source-oci-export.log"
+SOURCE_IMGREF="oci:/data/${SOURCE_OCI_DIR}"
+echo "Using source imgref: ${SOURCE_IMGREF}" | tee "${ARTIFACT_DIR}/source-imgref.txt"
+echo "::endgroup::"
+
 echo "::group::Generate qcow2 via bootc install-to-disk"
 mkdir -p "$(dirname "${RAW_PATH}")" "$(dirname "${QCOW_PATH}")"
 if command -v fallocate >/dev/null 2>&1; then
@@ -161,7 +169,7 @@ sudo podman run --rm --privileged --pid=host --pull=newer \
     -v /etc/containers:/etc/containers \
     -v "${PWD}:/data" \
     "${IMAGE_REF}" \
-    bootc install to-disk --composefs-backend --via-loopback "/data/${RAW_PATH}" --filesystem btrfs --wipe --bootloader systemd \
+    bootc install to-disk --source-imgref "${SOURCE_IMGREF}" --composefs-backend --via-loopback "/data/${RAW_PATH}" --filesystem btrfs --wipe --bootloader systemd \
     2>&1 | tee "${ARTIFACT_DIR}/bootc-install.log"
 
 qemu-img convert -O qcow2 "${RAW_PATH}" "${QCOW_PATH}"


### PR DESCRIPTION
## Summary
Fix the native `bootc install to-disk` image handoff so the repo has one coherent path for local qcow2 builds and CI VM smoke tests.

## Root cause
After PR #15, the image itself was bootc-valid, but the `build.yml` failures on `main` moved to the disk-image stage. CI copied the rootless-built image into rootful podman with `podman image save` / `podman image load`, and then `bootc install to-disk` failed reopening the source image from `containers-storage:` with missing config-blob errors.

## What changed
- Reused the existing rootful image-preload pattern in `Justfile` for the native `build-qcow2` and `build-raw` recipes.
- Switched `scripts/ci/vm-smoke.sh` from save/load to a storage-native `podman image scp` handoff.
- Resolved the canonical local image ref before the CI smoke script runs the rootful copy and install steps.
- Updated `README.md` and `docs/technical-status.md` so the repo reflects the current truth instead of the stale PR #14-era failure mode.

## Impact
- Local native qcow2/raw builds now explicitly preload the image into rootful podman before `bootc install to-disk`.
- CI uses the same handoff strategy instead of a divergent one.
- Open stale PRs can be closed because the remaining actionable fix is consolidated here.

## Validation
- `shellcheck build/10-base.sh build/20-omarchy.sh build/30-services.sh scripts/ci/vm-smoke.sh`
- `bash -n scripts/ci/vm-smoke.sh`
- `just --unstable --fmt --check -f Justfile`
- `just validate`
- Attempted `just build`, but the environment here did not finish pulling the Arch base image in a reasonable time.
- Rootful `just build-qcow2` / VM boot not run here because the host requires interactive `sudo`.